### PR TITLE
Update Terraform version, fix dependencies

### DIFF
--- a/delivery-platform/resources/provision/base_image/Dockerfile
+++ b/delivery-platform/resources/provision/base_image/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
                        apt-transport-https ca-certificates \
                        dnsutils curl gettext
 
-ENV TERRAFORM_VERSION=0.13.5
+ENV TERRAFORM_VERSION=1.0.3
 ENV HELM_VERSION=2.14.3
 ENV KUBECTL_VERSION=1.16.1
 ENV GO_VERSION=1.14.2

--- a/delivery-platform/resources/provision/clusters/tf/clusters.tf
+++ b/delivery-platform/resources/provision/clusters/tf/clusters.tf
@@ -20,7 +20,6 @@ locals {
 
 provider "google" {
   project = var.project_id
-  version = "~> 3.44.0"
 }
 
 data "google_compute_network" "delivery-platform" {

--- a/delivery-platform/resources/provision/clusters/tf/outputs.tf
+++ b/delivery-platform/resources/provision/clusters/tf/outputs.tf
@@ -26,13 +26,21 @@ output "staging__cluster-service-account" {
 
 output "dev_name" { value = module.delivery-platform-dev.name }
 output "dev_location" { value = module.delivery-platform-dev.location }
-output "dev_endpoint" { value = module.delivery-platform-dev.endpoint }
+output "dev_endpoint" {
+  value     = module.delivery-platform-dev.endpoint
+  sensitive = true
+}
 
 output "stage_name" { value = module.delivery-platform-staging.name }
 output "stage_location" { value = module.delivery-platform-staging.location }
-output "stage_endpoint" { value = module.delivery-platform-staging.endpoint }
+output "stage_endpoint" {
+  value     = module.delivery-platform-staging.endpoint
+  sensitive = true
+}
 
 output "prod_name" { value = module.delivery-platform-prod.name }
 output "prod_location" { value = module.delivery-platform-prod.location }
-output "prod_endpoint" { value = module.delivery-platform-prod.endpoint }
-
+output "prod_endpoint" {
+  value     = module.delivery-platform-prod.endpoint
+  sensitive = true
+}

--- a/delivery-platform/resources/provision/clusters/tf/versions.tf
+++ b/delivery-platform/resources/provision/clusters/tf/versions.tf
@@ -16,4 +16,10 @@
 
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.44.0"
+    }
+  }
 }

--- a/delivery-platform/resources/provision/foundation/tf/networks.tf
+++ b/delivery-platform/resources/provision/foundation/tf/networks.tf
@@ -15,7 +15,6 @@
  */
 
 provider "google" {
-  version = "~> 3.44.0"
   project = var.project_id
 }
 

--- a/delivery-platform/resources/provision/foundation/tf/services.tf
+++ b/delivery-platform/resources/provision/foundation/tf/services.tf
@@ -16,7 +16,7 @@
 
 module "project-services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 9.0"
+  version = "~> 11.1"
 
   project_id = var.project_id
 

--- a/delivery-platform/resources/provision/foundation/tf/versions.tf
+++ b/delivery-platform/resources/provision/foundation/tf/versions.tf
@@ -16,4 +16,10 @@
 
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.44.0"
+    }
+  }
 }


### PR DESCRIPTION
This PR bumps the version of Terraform to 1.0.3 (latest tested) to fix breaking changes in dependencies that had emerged with the previous, older version. It also updates (references to) dependencies and other areas that are required to support this new version, and unblocks future provider version updates. Fixes #12 .